### PR TITLE
Comment out non-existent binaries.

### DIFF
--- a/spartan_parallel/Cargo.toml
+++ b/spartan_parallel/Cargo.toml
@@ -40,15 +40,15 @@ curve25519-dalek = { git = "https://github.com/Jiangkm3/curve25519-dalek.git", b
 name = "libspartan"
 path = "src/lib.rs"
 
-[[bin]]
-name = "snark"
-path = "profiler/snark.rs"
-required-features = ["std"]
+# [[bin]]
+# name = "snark"
+# path = "profiler/snark.rs"
+# required-features = ["std"]
 
-[[bin]]
-name = "nizk"
-path = "profiler/nizk.rs"
-required-features = ["std"]
+# [[bin]]
+# name = "nizk"
+# path = "profiler/nizk.rs"
+# required-features = ["std"]
 
 [features]
 default = ["std", "simd_backend"]

--- a/spartan_parallel/Cargo.toml
+++ b/spartan_parallel/Cargo.toml
@@ -40,16 +40,6 @@ curve25519-dalek = { git = "https://github.com/Jiangkm3/curve25519-dalek.git", b
 name = "libspartan"
 path = "src/lib.rs"
 
-# [[bin]]
-# name = "snark"
-# path = "profiler/snark.rs"
-# required-features = ["std"]
-
-# [[bin]]
-# name = "nizk"
-# path = "profiler/nizk.rs"
-# required-features = ["std"]
-
 [features]
 default = ["std", "simd_backend"]
 std = [


### PR DESCRIPTION
There are two binary source code in `profile` that are deleted by #17, but the `[[bin]]` are still in Cargo.toml.