### PR TITLE
Sort out features and use cargo

### DIFF
--- a/circ_blocks/Cargo.toml
+++ b/circ_blocks/Cargo.toml
@@ -118,7 +118,7 @@ required-features = ["smt", "zok"]
 
 [[example]]
 name = "zxc"
-required-features = ["smt", "zok"]
+required-features = ["r1cs", "smt", "zok"]
 
 [[example]]
 name = "opa_bench"

--- a/encode_ceno.sh
+++ b/encode_ceno.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
-cd circ_blocks && target/release/examples/zxc ceno_demo/tower_verifier
+set -euxo pipefail
+
+cd circ_blocks
+
+cargo run --release \
+    --example zxc -- ceno_demo/tower_verifier

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,3 @@ set -euxo pipefail
   cd circ_blocks
   cargo build --release --example zxc --no-default-features --features r1cs,smt,zok
 )
-(
-  cd spartan_parallel
-  RUSTFLAGS="-C target_cpu=native" cargo build --release --features multicore,profile --example interface
-)

--- a/spartan_parallel/Cargo.toml
+++ b/spartan_parallel/Cargo.toml
@@ -78,3 +78,7 @@ std = [
 simd_backend = ["curve25519-dalek/simd_backend"]
 multicore = ["rayon"]
 profile = ["colored"]
+
+[[example]]
+name = "interface"
+required-features = ["multicore", "profile"]

--- a/verify_ceno.sh
+++ b/verify_ceno.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
-cd spartan_parallel && RUST_BACKTRACE=1 target/release/examples/interface ceno_demo/tower_verifier
+set -euxo pipefail
+
+cd spartan_parallel
+RUST_BACKTRACE=1 \
+    cargo run --release \
+        --example interface -- ceno_demo/tower_verifier


### PR DESCRIPTION
Sort out how we use features, and use cargo to run our examples, instead of directly specifying the path in the `target` directory.

This prepares for setting up the CI/CD.